### PR TITLE
Made minio-config script executable in entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       depends_on:
           minio:
               condition: service_started
-      entrypoint: [./minio-config.sh]
+      entrypoint: ["sh","-c","chmod +x /minio-config.sh && ./minio-config.sh"]
       environment:
           - HOST_IP_ADDRESS=${HOST_IP_ADDRESS}
           - S3_ROOT_USER=${S3_ROOT_USER}


### PR DESCRIPTION
Wird der docker stack unter Linux gestartet fehlt dem minio-config das executable flag. Das wir nur im entrypoint vom minio-config container mit gesetzt.