### PR TITLE
use concrete minio version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-restart-policy: &default_restart_policy
 
 services:
   mongo:
-    build: 
+    build:
       context: ./mongo
     <<: *default_restart_policy
     env_file:
@@ -77,6 +77,8 @@ services:
   minio:
     build:
       context: ./minio
+      args:
+          - MINIO_VER=RELEASE.2023-05-27T05-56-19Z
     <<: *default_restart_policy
     command: server /data --console-address ":9090"
     hostname: "minio"

--- a/minio/Dockerfile
+++ b/minio/Dockerfile
@@ -1,3 +1,4 @@
-FROM quay.io/minio/minio:latest
+ARG MINIO_VER
+FROM quay.io/minio/minio:$MINIO_VER
 
 # might get filled later on


### PR DESCRIPTION
Um böse Überraschungen zu vermeiden sollten wir einmal die MinIO-Version festzurren. 