### PR TITLE
None in arrays mit diagnosedaten

### DIFF
--- a/api/api/data_management/case.py
+++ b/api/api/data_management/case.py
@@ -74,9 +74,9 @@ class Case(Document):
     workshop_id: Indexed(str, unique=False)
 
     # diagnostic data
-    timeseries_data: List[Union[TimeseriesData, None]] = []
-    obd_data: List[Union[OBDData, None]] = []
-    symptoms: List[Union[Symptom, None]] = []
+    timeseries_data: List[TimeseriesData] = []
+    obd_data: List[OBDData] = []
+    symptoms: List[Symptom] = []
 
     # keep track of diagnostic data added to set appropriate data_ids
     timeseries_data_added: NonNegativeInt = 0

--- a/api/tests/data_management/test_case.py
+++ b/api/tests/data_management/test_case.py
@@ -671,11 +671,11 @@ class TestCase:
         async with initialized_beanie_context:
             # seed case with timeseries_data and save to db
             new_case["timeseries_data"] = [
-                timeseries_data, None, timeseries_data
+                timeseries_data, timeseries_data
             ]
             case = Case(workshop_id=1, **new_case)
             await case.save()
             await case._delete_all_timeseries_signals()
 
-            # delete_signal should have been awaited for each not None entry
+            # delete_signal should have been awaited for each not entry
             assert delete_signal.await_count == 2


### PR DESCRIPTION
In einem früheren Prototyp war es noch erlaubt, dass die Arrays mit Diagnosedaten `None` Einträge enthalten. Das ist nicht mehr nötig und deshalb habe ich die entsprechenden types angepasst.

CLOSES #30 