### PR TITLE
add azure extensions + update edc version

### DIFF
--- a/edc/gradle/build.gradle.kts
+++ b/edc/gradle/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation("$groupId:runtime-metamodel:$edcVersion")
 
     implementation("$groupId:control-plane-core:$edcVersion")
-    implementation("$groupId:data-plane-selector-core:$edcVersion")
+
     implementation("$groupId:api-observability:$edcVersion")
 
     implementation("$groupId:configuration-filesystem:$edcVersion")
@@ -32,9 +32,12 @@ dependencies {
     implementation("$groupId:aws-s3-core:$edcVersion")
     implementation("$groupId:data-plane-aws-s3:$edcVersion")
 
+    implementation("$groupId:data-plane-azure-storage:$edcVersion")
+
     implementation("$groupId:data-plane-selector-spi:$edcVersion")
     implementation("$groupId:data-plane-selector-client:$edcVersion")
     implementation("$groupId:data-plane-core:$edcVersion")
+    implementation("$groupId:data-plane-selector-core:$edcVersion")
 
     implementation("$groupId:transfer-data-plane:$edcVersion")
 }

--- a/edc/gradle/gradle.properties
+++ b/edc/gradle/gradle.properties
@@ -1,4 +1,4 @@
 groupId=org.eclipse.edc
-edcVersion=0.1.0
+edcVersion=0.1.2
 defaultVersion=0.0.1-SNAPSHOT
 javaVersion=11


### PR DESCRIPTION
Um uns perspektivisch an die Dekra-Azure-Cloud anzuschließen, habe ich einmal die (meines aktuellen Wissens nach einzig benötigte) entsprechende Azure Extension draufgepackt. 

https://github.com/eclipse-edc/Technology-Azure/tree/main/extensions/data-plane/data-plane-azure-storage

Prinzipiell sollte sich hiermit ein S3-Storage <-> Azure-Storage Transfer realisieren lassen. 