### PR TITLE
112 GitHub action timeout

### DIFF
--- a/.github/workflows/test-docker-stack.yml
+++ b/.github/workflows/test-docker-stack.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - 112-github-action-timeout
   pull_request:
     branches:
     - main


### PR DESCRIPTION
Reduced build time by removing buildx caching.