### PR TITLE
Feature/deploy docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,9 +3,9 @@ name: Build and publish docs
 on:
   push:
     branches:
-      - feature/deploy-docs
-    #paths:
-    #  - "docs/de/**"
+      - main
+    paths:
+      - "docs/de/**"
 jobs:
   build-docs:
     timeout-minutes: 10

--- a/docs/de/mkdocs.yml
+++ b/docs/de/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Autowerkstatt 4.0 - Hub
 site_author: | 
         Hochschule Osnabrück, 
         Technische Hochschule Georg Agricola, 
-        LMIS AG
+        LMIS AG 
 nav:
   - Hintergrund: 'background.md'
   - Technische Umsetzung:


### PR DESCRIPTION
Das Problem war wohl dass er den lokalen gh-pages branch immer neu erstellt hat anstatt den von origin vorher zu fetchen. Viele verwenden anscheinend einfach force push da eine history für die GH Page keinen Sinn macht. Das ist mir aber zu gefährlich solange die branch protection rules nicht greifen. 