### PR TITLE
Replacing cchardet with default encoding cp1252

### DIFF
--- a/api/api/upload_filereader/formats/vcds_txt.py
+++ b/api/api/upload_filereader/formats/vcds_txt.py
@@ -3,9 +3,9 @@ import logging as log
 import re
 from typing import BinaryIO, List
 
-import cchardet as chardet
-
 from ..filereader import FileReader, FileReaderException
+
+DEFAULT_FILE_ENCODING = 'cp1252'
 
 OBD_ERROR = re.compile(
     r"^\s*(?P<error_code>[BCPU][01][0-7][0-9A-Z]{2})\s"
@@ -20,12 +20,12 @@ VCDS_INFO = re.compile(
 
 
 class VCDSTXTReader(FileReader):
-    def read_file(self, file: BinaryIO) -> List[dict]:
-        enc = self.__determine_encoding(file)
+    def read_file(self,
+                  file: BinaryIO,
+                  enc: str = DEFAULT_FILE_ENCODING) -> List[dict]:
         return self.__read_vcds_txt(file, enc)
 
-    def probe(self, file: BinaryIO):
-        enc = self.__determine_encoding(file)
+    def probe(self, file: BinaryIO, enc: str = DEFAULT_FILE_ENCODING):
         validated = self.__get_obd_specs(file, enc)
         file.seek(0)
         return validated
@@ -53,11 +53,6 @@ class VCDSTXTReader(FileReader):
             raise FileReaderException(
                 "conversion failed: Failed to read filehead"
             )
-
-    def __determine_encoding(self, file: BinaryIO):
-        encoding = chardet.detect(file.read())['encoding']
-        file.seek(0)
-        return encoding
 
     def __read_vcds_txt(self, file: BinaryIO, enc: str):
         obd_specs = self.__get_obd_specs(file, enc)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,7 +4,6 @@ beanie==1.17.0
 motor==3.1.1
 numpy==1.24.2
 pytest-asyncio==0.20.3
-cchardet==2.1.7
 scipy==1.10.1
 python-multipart==0.0.6
 minio==7.1.15


### PR DESCRIPTION
Alle bisherigen VCDS Testdateien entsprechen cp1252 und da wir auch erweiterte Informationen wie VIN und MILAGE nur über deutsche Regex ausdrücken auslesen sehe ich keinen Grund weiter das encoding mit chardet zu raten (Was so oder so unzuverlässlich ist). Selbst wenn wir eine fremdsprachige Datei bekommen liegen die wichtigen Informationen wie VCDS_INFO und OBD Fehlercodes in ASCII bereich welcher von allen mir bekannten 8-bit basierten codierungen unterstützt wird.