### PR TITLE
Fix fromJson test

### DIFF
--- a/frontend/app/test/dto_test.dart
+++ b/frontend/app/test/dto_test.dart
@@ -423,7 +423,7 @@ void main() {
       expect(diagnosisDto.todos, todos);
     });
   });
-  /*group("DiagnosisDto fromJson constructor", () {
+  group("DiagnosisDto fromJson constructor", () {
     const id = "test_id";
     final timeStamp = DateTime.now();
     const status = DiagnosisStatus.failed;
@@ -436,7 +436,7 @@ void main() {
       "status": status.name,
       "case_id": caseId,
       "state_machine_log": stateMachineLog,
-      "todos": todos,
+      "todos": todos.map((e) => e.toJson()).toList(),
     };
     final DiagnosisDto diagnosisDto = DiagnosisDto.fromJson(json);
     test("correctly assigns id", () {
@@ -455,9 +455,9 @@ void main() {
       expect(diagnosisDto.stateMachineLog, stateMachineLog);
     });
     test("correctly assigns todos", () {
-      expect(diagnosisDto.todos, todos);
+      expect(diagnosisDto.todos, isA<List<ActionDto>>());
     });
-  });*/
+  });
   group("DiagnosisDto toJson method", () {
     const id = "test_id";
     final timeStamp = DateTime.now();


### PR DESCRIPTION
If a DTO has a property of type `SomeDto`, then it must be mapped like so `.map((e) => e.toJson()).toList()` when building the JSON object for the unit test.

When testing the output of `.fromJson()` constructors, it is then sufficient to check the type. Checking object values would be checking the `.fromJson()` constructor of `SomeDto`, which has its own unit tests.