### PR TITLE
Update test_frontend to checkout@v4

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -2,8 +2,8 @@
 
   on:
     pull_request:
-      paths:
-        - "frontend/**"
+      branches:
+        - main
   jobs:
     test_frontend:
       timeout-minutes: 10


### PR DESCRIPTION
- Upgrade von `checkout@v3` zu `checkout@v4`, da v3 Node v16 nutzt, die wiederum EOL ist (siehe bspw Warnung [hier](https://github.com/HS-OS-AG-Intelligente-Agrarsysteme/AW40-hub-docker/actions/runs/9501160959), noch mehr Infos [hier](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)).
- `test_frontend` läuft jetzt bei allen PRs auf main