### PR TITLE
Hotfix for python motor 

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.88.0
 uvicorn==0.20.0
 beanie==1.17.0
+pymongo==4.8.0
 motor==3.1.1
 numpy==1.24.2
 pytest-asyncio==0.20.3


### PR DESCRIPTION
Motor has loose requirements for pymongo just requiring a version pymongo>=4.5. Since pymongo 4.9.0 breaks motor pymongo == 4.8.0 has been added to requirements to force motor to use this version instead.

This Bug as of now affects all current branches.